### PR TITLE
Feature: Supports bringing your own backups

### DIFF
--- a/.github/workflows/mssql2019-posh5.yml
+++ b/.github/workflows/mssql2019-posh5.yml
@@ -3,7 +3,7 @@ name: mssql2019-posh5
 on:
   push:
     branches:
-      - main 
+      - '**'             # Run on all branches
   schedule:
     - cron: '0 3 * * *'  # Runs at 3am UTC every day
   workflow_dispatch:

--- a/.github/workflows/mssql2019-posh7.yml
+++ b/.github/workflows/mssql2019-posh7.yml
@@ -3,7 +3,7 @@ name: mssql2019-posh7
 on:
   push:
     branches:
-      - main 
+      - '**'             # Run on all branches
   schedule:
     - cron: '0 3 * * *'  # Runs at 3am UTC every day
   workflow_dispatch:

--- a/helper_scripts/helper-functions.psm1
+++ b/helper_scripts/helper-functions.psm1
@@ -1,0 +1,69 @@
+Function Install-Dbatools {
+    param (
+        $autoContinue = $false,
+        $trustCert = $true
+    )
+    # Installing and importing dbatools
+    if (Get-InstalledModule | Where-Object {$_.Name -like "dbatools"}){
+        # dbatools already installed
+        Write-Verbose "  dbatools PowerShell Module is installed."
+        return $true
+    }
+    else {
+        # dbatools not installed yet
+        Write-Verbose "  dbatools PowerShell Module is not installed"
+        Write-Verbose "    Installing dbatools (requires admin privileges)."
+
+        $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+        $runningAsAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        if (-not $runningAsAdmin){
+            Write-Error "    Script not running as admin. Please either install dbatools manually, or run this script as an administrator to enable installing PowerShell modules."
+            return $false
+        }
+        if ($autoContinue) {
+            install-module dbatools -Confirm:$False -Force
+        }
+        else {
+            install-module dbatools
+        }
+        
+    }
+    Write-Verbose "  Importing dbatools PowerShell module."
+    import-module dbatools
+
+    if ($trustCert){
+        Write-Warning "Note: For convenience, trustCert is set to true. This is not best practice. For more information about a more secure way to manage encryption/certificates, see this post by Chrissy LeMaire: https://blog.netnerds.net/2023/03/new-defaults-for-sql-server-connections-encryption-trust-certificate/"
+    }
+    if ($trustCert){
+        # Updating the dbatools configuration for this session only to trust server certificates and not encrypt connections
+        #   Note: This is not best practice. For more information about a more secure way to manage encyption/certificates, see this post by Chrissy LeMaire:
+        #   https://blog.netnerds.net/2023/03/new-defaults-for-sql-server-connections-encryption-trust-certificate/
+        Write-Verbose "    Updating dbatools configuration (for this session only) to trust server certificates, and not to encrypt connections."
+        Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true
+        Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false
+    }
+}
+# Export the function
+Export-ModuleMember -Function Install-Dbatools
+
+Function Build-SampleDatabases {
+    param (
+        [string]$ServerInstance = "localhost",
+        [string]$DatabaseName = "Northwind",
+        [string]$DataFilePath = "C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\SampleDB.mdf",
+        [string]$LogFilePath = "C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\SampleDB_log.ldf"
+    )
+
+    Write-Error "Implement this function"
+
+}
+
+Function Build-DatabaseFromBackup {
+    param (
+        [string]$ServerInstance = "localhost",
+        [string]$DatabaseName = "Northwind",
+        [string]$BackupFilePath = "C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\Backup\SampleDB.bak"
+    )
+
+    Write-Error "Implement this function"
+}

--- a/helper_scripts/helper-functions.psm1
+++ b/helper_scripts/helper-functions.psm1
@@ -42,6 +42,7 @@ Function Install-Dbatools {
         Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true
         Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false
     }
+    return $true
 }
 # Export the function
 Export-ModuleMember -Function Install-Dbatools

--- a/helper_scripts/rgsubset-options-generic.json
+++ b/helper_scripts/rgsubset-options-generic.json
@@ -1,0 +1,5 @@
+{
+    "jsonSchemaVersion": 1,
+    "desiredSize": "10GB",
+    "includeTablesRowThreshold": 300
+}

--- a/helper_scripts/rgsubset-options-generic.json
+++ b/helper_scripts/rgsubset-options-generic.json
@@ -1,5 +1,5 @@
 {
     "jsonSchemaVersion": 1,
-    "desiredSize": "10GB",
+    "desiredSize": "50MB",
     "includeTablesRowThreshold": 300
 }

--- a/helper_scripts/rgsubset-options-generic.json
+++ b/helper_scripts/rgsubset-options-generic.json
@@ -1,5 +1,0 @@
-{
-    "jsonSchemaVersion": 1,
-    "desiredSize": "50MB",
-    "includeTablesRowThreshold": 300
-}

--- a/helper_scripts/rgsubset-options-northwind.json
+++ b/helper_scripts/rgsubset-options-northwind.json
@@ -1,4 +1,5 @@
 {
+  "jsonSchemaVersion": 1,
   "startingTables": [
     { 
       "table":

--- a/run-auto-masklet.ps1
+++ b/run-auto-masklet.ps1
@@ -17,6 +17,11 @@ $fullRestoreCreateScript = "$PSScriptRoot/helper_scripts/CreateNorthwindFullRest
 $subsetCreateScript = "$PSScriptRoot/helper_scripts/CreateNorthwindSubset.sql"
 $installTdmClisScript = "$PSScriptRoot/helper_scripts/installTdmClis.ps1"
 $helperFunctions = "$PSScriptRoot/helper_scripts/helper-functions.psm1"
+$subsetterOptionsFile = "$PSScriptRoot\helper_scripts\rgsubset-options-northwind.json"
+if ($backupPath){
+    $subsetterOptionsFile = "$PSScriptRoot\helper_scripts\rgsubset-options-generic.json"
+}
+
 $winAuth = $true
 $sourceConnectionString = ""
 $targetConnectionString = ""
@@ -30,6 +35,7 @@ else {
     $sourceConnectionString = "server=$sqlInstance;database=$sourceDb;TrustServerCertificate=yes;User Id=$sqlUser;Password=$sqlPassword;"
     $targetConnectionString = "server=$sqlInstance;database=$targetDb;TrustServerCertificate=yes;User Id=$sqlUser;Password=$sqlPassword;"
 }
+
 
 Write-Output "Configuration:"
 Write-Output "- sqlInstance:             $sqlInstance"
@@ -174,7 +180,7 @@ Write-Output "  ORDER BY o.OrderID ASC;"
 Write-Output ""
 Write-Output "Next:"
 Write-Output "We will run the following rgsubset command to copy a subset of the data from $sourceDb to $targetDb."
-Write-Output "  rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file `".\helper_scripts\rgsubset-options.json`" --target-database-write-mode Overwrite"
+Write-Output "  rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file `"$subsetterOptionsFile`" --target-database-write-mode Overwrite"
 Write-Output "The subset will include data from the $startingTable table, based on the filter clause $filterClause."
 Write-Output "It will also include any data from any other tables that are required to maintain referential integrity."
 Write-Output "*********************************************************************************************************"
@@ -191,7 +197,7 @@ if (-not $autoContinue){
 # running subset
 Write-Output ""
 Write-Output "Running rgsubset to copy a subset of the data from $sourceDb to $targetDb."
-rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file ".\helper_scripts\rgsubset-options.json" --target-database-write-mode Overwrite
+rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"

--- a/run-auto-masklet.ps1
+++ b/run-auto-masklet.ps1
@@ -212,7 +212,7 @@ if (-not $autoContinue){
 # running subset
 Write-Output ""
 Write-Output "Running rgsubset to copy a subset of the data from $sourceDb to $targetDb."
-rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite 2>&1 | Out-Host
+rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite
 
 
 Write-Output ""
@@ -235,7 +235,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Creating a classification.json file in $output"
-rganonymize classify --database-engine SqlServer --connection-string=$targetConnectionString --classification-file "$output\classification.json" --output-all-columns 2>&1
+rganonymize classify --database-engine SqlServer --connection-string=$targetConnectionString --classification-file "$output\classification.json" --output-all-columns
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"
@@ -262,7 +262,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Creating a masking.json file based on contents of classification.json in $output"
-rganonymize map --classification-file="$output\classification.json" --masking-file="$output\masking.json" 2>&1
+rganonymize map --classification-file="$output\classification.json" --masking-file="$output\masking.json"
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"
@@ -288,7 +288,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Masking target database, based on contents of masking.json file in $output"
-rganonymize mask --database-engine SqlServer --connection-string=$targetConnectionString --masking-file="$output\masking.json" 2>&1
+rganonymize mask --database-engine SqlServer --connection-string=$targetConnectionString --masking-file="$output\masking.json"
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"

--- a/run-auto-masklet.ps1
+++ b/run-auto-masklet.ps1
@@ -132,7 +132,7 @@ Write-Output ""
 # Building staging databases
 if ($backupPath) {
     # Using the Restore-StagingDatabasesFromBackup function in helper-functions.psm1 to build source and target databases from an existing backup
-    Write-Output "  Building sample Northwind source and target databases."
+    Write-Output "  Building $sourceDb and $targetDb databases from backup file saved at $BackupPath."
     $dbCreateSuccessful = Restore-StagingDatabasesFromBackup -WinAuth:$winAuth -sqlInstance:$sqlInstance -sourceDb:$sourceDb -targetDb:$targetDb -sourceBackupPath:$backupPath -SqlCredential:$SqlCredential
     if ($dbCreateSuccessful){
         Write-Output "    Source and target databases created successfully."
@@ -212,7 +212,8 @@ if (-not $autoContinue){
 # running subset
 Write-Output ""
 Write-Output "Running rgsubset to copy a subset of the data from $sourceDb to $targetDb."
-rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite
+rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite 
+
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"
@@ -234,7 +235,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Creating a classification.json file in $output"
-rganonymize classify --database-engine SqlServer --connection-string=$targetConnectionString --classification-file "$output\classification.json" --output-all-columns 
+rganonymize classify --database-engine SqlServer --connection-string=$targetConnectionString --classification-file "$output\classification.json" --output-all-columns 2>&1
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"
@@ -261,7 +262,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Creating a masking.json file based on contents of classification.json in $output"
-rganonymize map --classification-file="$output\classification.json" --masking-file="$output\masking.json" 
+rganonymize map --classification-file="$output\classification.json" --masking-file="$output\masking.json" 2>&1
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"
@@ -287,7 +288,7 @@ if (-not $autoContinue){
 }
 
 Write-Output "Masking target database, based on contents of masking.json file in $output"
-rganonymize mask --database-engine SqlServer --connection-string=$targetConnectionString --masking-file="$output\masking.json" 
+rganonymize mask --database-engine SqlServer --connection-string=$targetConnectionString --masking-file="$output\masking.json" 2>&1
 
 Write-Output ""
 Write-Output "*********************************************************************************************************"

--- a/run-auto-masklet.ps1
+++ b/run-auto-masklet.ps1
@@ -18,9 +18,6 @@ $subsetCreateScript = "$PSScriptRoot/helper_scripts/CreateNorthwindSubset.sql"
 $installTdmClisScript = "$PSScriptRoot/helper_scripts/installTdmClis.ps1"
 $helperFunctions = "$PSScriptRoot/helper_scripts/helper-functions.psm1"
 $subsetterOptionsFile = "$PSScriptRoot\helper_scripts\rgsubset-options-northwind.json"
-if ($backupPath){
-    $subsetterOptionsFile = "$PSScriptRoot\helper_scripts\rgsubset-options-generic.json"
-}
 
 $winAuth = $true
 $sourceConnectionString = ""
@@ -196,8 +193,13 @@ else {
 Write-Output ""
 Write-Output "Next:"
 Write-Output "We will run the following rgsubset command to copy a subset of the data from $sourceDb to $targetDb."
-Write-Output "  rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file `"$subsetterOptionsFile`" --target-database-write-mode Overwrite"
-Write-Output "The subset will include data from the $startingTable table, based on the options set here: $subsetterOptionsFile."
+if ($backupPath){
+    Write-Output "  rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --target-database-write-mode Overwrite"
+}
+else {
+    Write-Output "  rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file `"$subsetterOptionsFile`" --target-database-write-mode Overwrite"
+    Write-Output "The subset will include data from the starting table, based on the options set here: $subsetterOptionsFile."
+}
 Write-Output "*********************************************************************************************************"
 Write-Output ""
 
@@ -212,7 +214,12 @@ if (-not $autoContinue){
 # running subset
 Write-Output ""
 Write-Output "Running rgsubset to copy a subset of the data from $sourceDb to $targetDb."
-rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite
+if ($backupPath){
+    rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --target-database-write-mode Overwrite
+}
+else {
+    rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite
+}
 
 
 Write-Output ""

--- a/run-auto-masklet.ps1
+++ b/run-auto-masklet.ps1
@@ -212,7 +212,7 @@ if (-not $autoContinue){
 # running subset
 Write-Output ""
 Write-Output "Running rgsubset to copy a subset of the data from $sourceDb to $targetDb."
-rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite 
+rgsubset run --database-engine=sqlserver --source-connection-string=$sourceConnectionString --target-connection-string=$targetConnectionString --options-file="$subsetterOptionsFile" --target-database-write-mode Overwrite 2>&1 | Out-Host
 
 
 Write-Output ""


### PR DESCRIPTION
Adds the $BackupPath parameter.

If used, instead of using sample Northwind databases, it will restore the backup twice: once for the source, and once for the target. 
It will also use a new generic options file, with a target size set to 10MB. This avoids the need to specify any starting tables up front.